### PR TITLE
Midnight compatible and optional integration with Grail & PrintQuests

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -6,9 +6,20 @@ function Addon:OnInitialize() ns.DB = LibStub('AceDB-3.0'):New('QuestTrackerDB',
 
 function Addon:OnEnable()
     self:InitQDB()
-    ns.HistoryFrame:Init()
+    ns.HistoryFrame:HookScript('OnShow', function(self)
+        if not self.initialized then
+            self:Init()
+            self.initialized = true
+        end
+    end)
+    self:RegisterEvent('PLAYER_ENTERING_WORLD')
     self:RegisterEvent('QUEST_LOG_UPDATE')
     self:RegisterEvent('QUEST_DATA_LOAD_RESULT')
+end
+
+function Addon:PLAYER_ENTERING_WORLD()
+    self:UnregisterEvent('PLAYER_ENTERING_WORLD')
+    self:MigrateQDB()
 end
 
 function Addon:InitQDB()
@@ -16,10 +27,85 @@ function Addon:InitQDB()
     for _, id in pairs(quests) do if not ns.DB.char.Quests[id] then ns.DB.char.Quests[id] = {completed = true} end end
 end
 
+-- Resolves a quest title: WoW API → Grail → PrintQuests → unknown
+-- Returns: title (string), trackingType ('confident'|'unsure'|'unknown'|nil)
+-- trackingType nil means WoW provided the title directly (normal quest).
+local function ResolveTitle(id)
+    local title = C_QuestLog.GetTitleForQuestID(id)
+    if title then return title, nil end
+
+    if Grail and Grail.QuestName then
+        local grailName = Grail:QuestName(id)
+        if grailName then return grailName, 'confident' end
+    end
+
+    if PrintQuests then
+        if PrintQuests.ConfidentlyNamedTrackingQuests and PrintQuests.ConfidentlyNamedTrackingQuests[id] then
+            return PrintQuests.ConfidentlyNamedTrackingQuests[id], 'confident'
+        elseif PrintQuests.UnsurelyNamedTrackingQuests and PrintQuests.UnsurelyNamedTrackingQuests[id] then
+            return PrintQuests.UnsurelyNamedTrackingQuests[id], 'unsure'
+        end
+    end
+
+    return 'Hidden/Tracking Quest', 'unknown'
+end
+
+-- Migrates old DB entries that predate the trackingType field.
+-- 'Pending ...' entries not found in Grail/PrintQuests are re-requested from WoW.
+-- 'unknown' entries are re-checked every login in case Grail/PrintQuests now has a name.
+local migrationPending = {}
+
+local function resolveFromGrailOrPrintQuests(id, quest)
+    if Grail and Grail.QuestName then
+        local grailName = Grail:QuestName(id)
+        if grailName then
+            quest.title = grailName
+            quest.trackingType = 'confident'
+            return true
+        end
+    end
+    if PrintQuests and PrintQuests.ConfidentlyNamedTrackingQuests and PrintQuests.ConfidentlyNamedTrackingQuests[id] then
+        quest.title = PrintQuests.ConfidentlyNamedTrackingQuests[id]
+        quest.trackingType = 'confident'
+        return true
+    elseif PrintQuests and PrintQuests.UnsurelyNamedTrackingQuests and PrintQuests.UnsurelyNamedTrackingQuests[id] then
+        quest.title = PrintQuests.UnsurelyNamedTrackingQuests[id]
+        quest.trackingType = 'unsure'
+        return true
+    end
+    return false
+end
+
+function Addon:MigrateQDB()
+    for id, quest in pairs(ns.DB.char.Quests) do
+        if quest.trackingType == 'unknown' then
+            -- Re-check each login: Grail or PrintQuests might now have a name
+            resolveFromGrailOrPrintQuests(id, quest)
+            -- else: still unknown, leave as is
+
+        elseif quest.trackingType ~= nil then
+            -- confident/unsure: already evaluated, skip
+
+        elseif quest.title == nil or quest.title == 'Hidden/Tracking Quest' or quest.title == 'Pending ...' then
+            if not resolveFromGrailOrPrintQuests(id, quest) then
+                if quest.title == 'Pending ...' then
+                    -- Not in Grail or PrintQuests – re-request from WoW, handled in QUEST_DATA_LOAD_RESULT
+                    migrationPending[id] = true
+                    C_QuestLog.RequestLoadQuestByID(id)
+                else
+                    quest.trackingType = 'unknown'
+                end
+            end
+        end
+    end
+end
+
+-------------------------------------------------------------------------------
+
 local processedQuests = {}
 
 function Addon:QUEST_LOG_UPDATE()
-    processedQuests = {} -- Reset processed quests for each update
+    processedQuests = {}
     ns.changedQuests = ns.QuestHistory:GetChangedQuests() or {quests = {}, counter = 0}
     if ns.changedQuests.counter > 0 then
         ns.QuestHistory:UpdateQuestDB(true)
@@ -28,19 +114,27 @@ function Addon:QUEST_LOG_UPDATE()
 end
 
 function Addon:QUEST_DATA_LOAD_RESULT(e, id, success)
-    if not ns.changedQuests or not ns.changedQuests.quests or not ns.changedQuests.quests[id] then return end
+    local isMigration = migrationPending[id]
+    local isChanged = ns.changedQuests and ns.changedQuests.quests and ns.changedQuests.quests[id]
 
-    -- Prevent duplicate processing
+    if not isMigration and not isChanged then return end
     if processedQuests[id] then return end
     processedQuests[id] = true
 
     if ns.DB.char.Quests[id] and ns.DB.char.Quests[id].completed ~= nil then
-        ns.DB.char.Quests[id].title = C_QuestLog.GetTitleForQuestID(id) or 'Hidden/Tracking Quest'
+        local title, trackingType = ResolveTitle(id)
+        ns.DB.char.Quests[id].title = title
+        ns.DB.char.Quests[id].trackingType = trackingType
+
+        migrationPending[id] = nil
         ns.HistoryFrame:Refresh()
 
-        local tru, fls = '|cFF00FF00TRUE|r', '|cFFFF0000FALSE|r'
-        local change = ns.DB.char.Quests[id].completed and tru or fls
-        ns.Print(format('Quest [%d] (%s) changed to %s', id, ns.DB.char.Quests[id].title, change))
+        -- Only print chat message for newly changed quests, not migrations
+        if isChanged then
+            local tru, fls = '|cFF00FF00TRUE|r', '|cFFFF0000FALSE|r'
+            local change = ns.DB.char.Quests[id].completed and tru or fls
+            ns.Print(format('Quest [%d] (%s) changed to %s', id, title, change))
+        end
     end
 end
 
@@ -54,7 +148,7 @@ function ns.Print(...) Addon:Print(...) end
 
 Addon:RegisterChatCommand('QT', function() if ns.HistoryFrame then ns.HistoryFrame:Show() end end)
 
--- Debug    
+-- Debug
 Addon:RegisterChatCommand('QTflush', function()
     ns.DB.char.Quests = {}
     Addon:InitQDB()
@@ -71,6 +165,37 @@ ns.printQDB = function()
         if type(v) == 'table' then for x, y in pairs(v) do ns.Print("--", x, y) end end
     end
 end
+Addon:RegisterChatCommand('QTmissing', function()
+    local list = {}
+    for id, quest in pairs(ns.DB.char.Quests) do
+        if not quest.title or quest.title == 'Pending ...' or quest.title == 'Hidden/Tracking Quest' then
+            table.insert(list, {
+                id           = id,
+                title        = quest.title,
+                trackingType = quest.trackingType,
+                time         = quest.time or 0,
+            })
+        end
+    end
+    table.sort(list, function(a, b) return a.time > b.time end)
+
+    -- Persist to SavedVars
+    ns.DB.char.MissingQuestsLog = {
+        scannedAt = time(),
+        quests    = list,
+    }
+
+    -- Print sorted
+    for _, q in ipairs(list) do
+        ns.Print(format('[%s] Quest [%d] trackingType=%s title=%s',
+            q.time > 0 and date('%d.%m %H:%M', q.time) or '??',
+            q.id,
+            tostring(q.trackingType),
+            tostring(q.title)
+        ))
+    end
+    ns.Print(format('Total missing: %d  (gespeichert in MissingQuestsLog)', #list))
+end)
 
 -------------------------------------------------------------------------------
 

--- a/HistoryFrame.lua
+++ b/HistoryFrame.lua
@@ -5,30 +5,82 @@ local HistoryFrame = CreateFrame('Frame', ADDON_NAME .. 'HistoryFrame', nil, ADD
 function HistoryFrame:Init()
     self:SetTitle(ADDON_NAME .. ' History')
 
+    local titleWidth = nil
+    local measureText = nil
+    local needsHeightRefresh = false
+    local COL_MAP_LEFT    = nil
+    local COL_MAP_W       = 100
+    local COL_POS_LEFT    = nil
+    local COL_POS_W       = 90
+    local COL_TIME_W      = 90
+
+    local LINE_PAD = 6
+
     local initializer = function(line, quest)
-        line:SetHighlightAtlas('auctionhouse-ui-row-highlight')
+        if not titleWidth then
+            local totalW     = self.QuestList.ScrollBox:GetWidth()
+            COL_TIME_W       = 110
+            COL_POS_W        = 100
+            COL_MAP_W        = 140
+            COL_POS_LEFT     = totalW - COL_TIME_W - COL_POS_W
+            COL_MAP_LEFT     = COL_POS_LEFT - COL_MAP_W
+            titleWidth       = COL_MAP_LEFT - 70 - 5
+            measureText = self.QuestList:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightLeft')
+            measureText:SetWidth(titleWidth)
+            measureText:SetWordWrap(true)
+            measureText:Hide()
+            needsHeightRefresh = true
+        end
         if not line.Id then
             line.Id = line:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightRight')
-            line.Id:SetPoint('LEFT', 10, 0)
+            line.Id:SetPoint('LEFT', 5, 0)
+            line.Id:SetWidth(55)
 
             line.Title = line:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightLeft')
-            line.Title:SetPoint('LEFT', 70, 0)
+            line.Title:SetPoint('LEFT', line, 'LEFT', 70, 0)
+            line.Title:SetWidth(titleWidth)
+            line.Title:SetWordWrap(true)
 
             line.Map = line:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightLeft')
-            line.Map:SetPoint('RIGHT', -220, 0)
+            line.Map:SetPoint('LEFT', line, 'LEFT', COL_MAP_LEFT, 0)
+            line.Map:SetWidth(COL_MAP_W)
 
             line.Position = line:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightLeft')
-            line.Position:SetPoint('RIGHT', -120, 0)
+            line.Position:SetPoint('LEFT', line, 'LEFT', COL_POS_LEFT, 0)
+            line.Position:SetWidth(COL_POS_W)
 
             line.Time = line:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightRight')
             line.Time:SetPoint('RIGHT')
+            line.Time:SetWidth(COL_TIME_W)
         end
 
-        line.Title:SetText(quest.title)
+        -- Color title based on tracking type:
+        --   confident  = orange  (known tracking quest name)
+        --   unsure     = yellow  (guessed tracking quest name)
+        --   unknown    = red     (no name found anywhere)
+        --   nil        = default (WoW provided the title)
+        local trackingType = ns.DB.char.Quests[quest.id] and ns.DB.char.Quests[quest.id].trackingType
+        local titleText = quest.title or UNKNOWN
+        if trackingType == 'confident' then
+            titleText = '|cFFFF8C00' .. titleText .. '|r'
+        elseif trackingType == 'unsure' then
+            titleText = '|cFFFFFF00' .. titleText .. '|r'
+        elseif trackingType == 'unknown' then
+            titleText = '|cFFFF4444' .. titleText .. '|r'
+        end
+
+        line.Title:SetText(titleText)
         line.Map:SetText(quest.map)
         line.Position:SetText(format('%.2f %.2f', quest.pos.x * 100 or 0, quest.pos.y * 100 or 0))
         line.Id:SetText(quest.id)
         line.Time:SetText(ns.DB.char.Quests[quest.id].time and date('%d.%m %H:%M:%S', quest.time) or UNKNOWN)
+
+        -- After the first initializer run, measureText exists and heights can be
+        -- properly calculated. Trigger one Refresh so the ExtentCalculator re-runs.
+        if needsHeightRefresh then
+            needsHeightRefresh = false
+            C_Timer.After(0, function() self:Refresh() end)
+        end
     end
 
     local dataProvider = CreateDataProvider(ns.QuestList())
@@ -36,21 +88,28 @@ function HistoryFrame:Init()
     self.dataProvider = dataProvider
 
     local ScrollView = CreateScrollBoxListLinearView()
-    ScrollView:SetElementExtent(20)
+    ScrollView:SetElementExtent(20)  -- minimum / pool hint
+    ScrollView:SetElementExtentCalculator(function(dataIndex, elementData)
+        if not measureText then return 20 end
+        -- Strip color codes before measuring so they don't affect line breaks
+        local titleText = (elementData.title or ''):gsub('|c%x%x%x%x%x%x%x%x', ''):gsub('|r', '')
+        measureText:SetText(titleText)
+        return math.max(20, measureText:GetStringHeight() + LINE_PAD)
+    end)
     ScrollView:SetElementInitializer('Button', initializer)
-    ScrollView:SetDataProvider(self.dataProvider)
     self.ScrollView = ScrollView
 
-    ScrollUtil.InitScrollBoxWithScrollBar(self.QuestList.ScrollBox, self.QuestList.ScrollBar, ScrollView)
+    ScrollUtil.InitScrollBoxListWithScrollBar(self.QuestList.ScrollBox, self.QuestList.ScrollBar, ScrollView)
+    self.QuestList.ScrollBox:SetDataProvider(self.dataProvider)
 
     self.QuestList:Show()
 end
 
 function HistoryFrame:Refresh()
+    if not self.dataProvider then return end
     self.dataProvider:Flush()
     self.dataProvider:InsertTable(ns.QuestList())
     self.dataProvider:Sort()
-    self.ScrollView:SetDataProvider(self.dataProvider)
 end
 
 ns.HistoryFrame = HistoryFrame

--- a/HistoryFrame.xml
+++ b/HistoryFrame.xml
@@ -1,7 +1,7 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
     <Frame name="QuestTrackerHistoryFrameTemplate" hidden="true" parent="UIParent" enableMouse="true" movable="true" clampedToScreen="true" virtual="true" inherits="DefaultPanelFlatTemplate">
         <Size>
-            <AbsDimension x="650" y="300"></AbsDimension>
+            <AbsDimension x="850" y="420"></AbsDimension>
         </Size>
         <Anchors>
             <Anchor point="CENTER"></Anchor>

--- a/QuestTracker.toc
+++ b/QuestTracker.toc
@@ -1,4 +1,4 @@
-## Interface: 100100
+## Interface: 120001, 120005
 ## Title: QuestTracker
 ## Author: Ioney
 ## Version: 0.2


### PR DESCRIPTION
- update Interface version to Midnight
- widen the HistoryFrame
- make use of Grail and PrintQuests to name quests if the game doesn't return a title, if available